### PR TITLE
Support for django 4.0+

### DIFF
--- a/markdown_view/loaders.py
+++ b/markdown_view/loaders.py
@@ -46,7 +46,7 @@ class MarkdownLoader(FilesystemLoader):
             template_app_dir = template_split.pop()
             template_split.reverse()
             for template_dir in self.get_dirs():
-                if template_dir.endswith(template_app_dir):
+                if str(template_dir).endswith(template_app_dir):
                     try:
                         name = safe_join(template_dir, *template_split)
                     except SuspiciousFileOperation:


### PR DESCRIPTION
## Problem
Since django 4.0 path methods have been migrated from using plain string to `pathlib.Path`'s, as such `get_app_template_dirs` now returns Path objects. This breaks the endswith check used in the code for all django versions >4.0.

## Changes
This fix manually casts the path object to a string, to reenable the former functionality.
This should not break backwards compatability for versions before 4.0 since `str(string)` is equivalent to the string itself.