### PR TITLE
Handle markdown files without TOC headers

### DIFF
--- a/markdown_view/tests/settings.py
+++ b/markdown_view/tests/settings.py
@@ -1,0 +1,17 @@
+SECRET_KEY = "test-key"
+
+INSTALLED_APPS = [
+    "django.contrib.auth",
+    "django.contrib.contenttypes",
+    "markdown_view",
+]
+
+TEMPLATES = [
+    {
+        "BACKEND": "django.template.backends.django.DjangoTemplates",
+        "APP_DIRS": True,
+    }
+]
+
+ROOT_URLCONF = "markdown_view.tests.urls"
+USE_TZ = True

--- a/markdown_view/tests/test_views.py
+++ b/markdown_view/tests/test_views.py
@@ -1,0 +1,27 @@
+from pathlib import Path
+from tempfile import TemporaryDirectory
+
+from django.test import RequestFactory, SimpleTestCase, override_settings
+
+from markdown_view.views import MarkdownView
+
+
+class MarkdownViewTOCTests(SimpleTestCase):
+    def setUp(self):
+        self.request = RequestFactory().get("/docs/")
+
+    def test_toc_without_headers_does_not_error(self):
+        with TemporaryDirectory() as temp_dir:
+            temp_path = Path(temp_dir)
+            file_name = "docs/README.md"
+            (temp_path / "README.md").write_text("plain content without headers", encoding="utf-8")
+
+            view = MarkdownView.as_view(file_name=file_name)
+            with override_settings(MARKDOWN_VIEW_BASE_DIR=temp_path):
+                response = view(self.request)
+                response.render()
+
+            self.assertEqual(response.status_code, 200)
+            self.assertTrue(response.context_data["use_toc"])
+            self.assertIn("markdown_toc", response.context_data)
+            self.assertNotIn("page_title", response.context_data)

--- a/markdown_view/tests/urls.py
+++ b/markdown_view/tests/urls.py
@@ -1,0 +1,1 @@
+urlpatterns = []

--- a/markdown_view/views.py
+++ b/markdown_view/views.py
@@ -65,11 +65,14 @@ class MarkdownView(TemplateView):
                     "MARKDOWN_VIEW_TEMPLATE_USE_TOC",
                     DEFAULT_MARKDOWN_VIEW_TEMPLATE_USE_TOC
             ):
-                context.update({
+                toc_context = {
                     "markdown_toc": mark_safe(md.toc),
-                    "page_title": mark_safe(md.toc_tokens[0]['name']),
                     "use_toc": True,
-                })
+                }
+                toc_tokens = getattr(md, "toc_tokens", []) or []
+                if toc_tokens and "name" in toc_tokens[0]:
+                    toc_context["page_title"] = mark_safe(toc_tokens[0]["name"])
+                context.update(toc_context)
 
         return context
 


### PR DESCRIPTION
### Motivation
- Prevent an IndexError when rendering the TOC for Markdown files that contain no header tokens by avoiding unconditional access to `md.toc_tokens[0]['name']`.

### Description
- Guard TOC context building in `MarkdownView` so `page_title` is only set when `md.toc_tokens` contains a first token with a `name` key. 
- Replace the previous direct indexing with a safe check using `getattr(md, "toc_tokens", []) or []` and conditional assignment of `page_title`.
- Add a minimal test suite under `markdown_view/tests` including `test_views.py`, `settings.py`, `urls.py`, and `__init__.py` to exercise rendering a markdown file without headers.

### Testing
- `python -m compileall markdown_view markdown_view/tests` completed successfully and compiled the new test modules. 
- Attempted `python -m django test markdown_view.tests --settings=markdown_view.tests.settings` but it failed in this environment because `django` is not installed. 
- `pytest -q` previously reported no tests run in this environment before adding the Django test scaffolding.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69c59f07a14083239819062000b9232a)